### PR TITLE
Add NordicExpat guide to a new Nordics section

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@
 
 * [Awesome Living in Korea](https://github.com/seoulstart/awesome-living-in-korea) - Curated list of resources for foreign residents in Korea: visa categories, ARC registration, housing (jeonse/wolse), NHIS health insurance, banking, taxes, work, and Korean government portals. Available in English, Korean, Vietnamese, Filipino, Russian, and Chinese.
 
+### Nordics (Denmark, Sweden, Norway, Finland)
+
+* [NordicExpat](https://nordicexpat.com) - Comprehensive relocation guides for non-EU expats moving to Denmark, Sweden, Norway, and Finland. Covers banking (Wise, Revolut), housing, taxes, healthcare, visas, and everyday life. Includes free tools: Copenhagen zone calculator, Nordic tax calculators, and country-specific benefit guides. 160+ in-depth articles authored by an expat in the region.
+
 ## Interviewing
 
 * [Awesome Interview Questions](https://github.com/MaximAbramchuck/awesome-interview-questions) - A curated awesome list of lists of interview questions.


### PR DESCRIPTION
## What this adds

A new `### Nordics` subsection under **Knowing about**, linking to [NordicExpat](https://nordicexpat.com).

## Why it fits

The list already has country-specific subsections (Germany, Berlin, Italy, Korea) but none for the Nordic countries, despite Denmark, Sweden, Norway, and Finland being common destinations for expats. NordicExpat covers what someone relocating there needs most:

- Banking setup (Wise/Revolut before arrival, local bank requirements)
- CPR / personnummer registration
- Housing search per country
- Tax systems and benefit entitlements
- Healthcare registration (SKAT, Skatteverket, Skatteetaten, Kela)
- Visa categories for non-EU nationals

It also includes free interactive tools (a Copenhagen public-transport zone calculator and Nordic tax calculators) and 160+ country-specific articles written by an expat living in the region.

## Checklist
- [x] Link is live and loads correctly
- [x] Relevant to the list's audience
- [x] No duplicate entry exists
- [x] Follows the existing `* [Name](URL) - Description` format