### PR TITLE
Add US Expat Tax Guide (state domicile) to Finances

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@
 * [Xoom](https://www.xoom.com/) - The easiest way to send money, reload phones, and pay bills worldwide.
 * [German Salary Calculator](https://lohntastik.de/gns/gross-net-salary-calculator) - The calculator will assist you in determining how much of your gross salary will remain after taxes and social contributions have been deducted.
 * [FEIE vs Foreign Tax Credit Calculator](https://expatcove.com/feie-vs-foreign-tax-credit-calculator/) - Free, no-signup calculator for US citizens abroad: runs both tax elections (Foreign Earned Income Exclusion / Form 2555 and the Foreign Tax Credit / Form 1116) on official 2025/2026 IRS brackets and shows which one keeps more.
+* [US Expat Tax Guide: Maintaining Florida Domicile](https://yourtaxbase.com/expat-tax-guide) - Free 2026 guide for US citizens abroad on legally eliminating state income tax by keeping domicile in a no-tax state, alongside federal exclusions and filing requirements.
 ## Misc
 
 * [SeeYourFolks](http://seeyourfolks.com) - We’re so busy growing up that we sometimes forget that they are also growing old.


### PR DESCRIPTION
Adds a free 2026 guide for US citizens abroad to the Finances section. It covers a state-domicile angle none of the current entries do: how expats legally eliminate US state income tax by keeping domicile in a no-tax state. It's distinct from the existing FEIE vs Foreign Tax Credit calculator, which handles federal elections; this is a guide about state residency.

Full disclosure: this is a resource we publish and maintain. It's free with no signup, and I'm including it only because it fills a specific gap. Happy to adjust the wording or placement, or close this out, if you'd prefer not to list it.