### PR TITLE
Add Nordic Take-Home Pay Calculator to Finances

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@
 * [Xoom](https://www.xoom.com/) - The easiest way to send money, reload phones, and pay bills worldwide.
 * [German Salary Calculator](https://lohntastik.de/gns/gross-net-salary-calculator) - The calculator will assist you in determining how much of your gross salary will remain after taxes and social contributions have been deducted.
 * [FEIE vs Foreign Tax Credit Calculator](https://expatcove.com/feie-vs-foreign-tax-credit-calculator/) - Free, no-signup calculator for US citizens abroad: runs both tax elections (Foreign Earned Income Exclusion / Form 2555 and the Foreign Tax Credit / Form 1116) on official 2025/2026 IRS brackets and shows which one keeps more.
+* [Nordic Take-Home Pay Calculator](https://nordicexpat.com/tools) - Free, no-signup gross-to-net salary calculators for Denmark, Sweden, Norway, and Finland on official 2026 tax rates, plus feriepenge (holiday pay), dagpenge, and gross-up tools.
 * [US Expat Tax Guide: Maintaining Florida Domicile](https://yourtaxbase.com/expat-tax-guide) - Free 2026 guide for US citizens abroad on legally eliminating state income tax by keeping domicile in a no-tax state, alongside federal exclusions and filing requirements.
 * [Awesome Digital Nomads](https://github.com/cloudfloo/awesome-digital-nomads) - Curated, link-checked list of tools and resources for digital nomads: finance and FIRE, visas, insurance, eSIMs, accommodation, and communities.
 ## Misc


### PR DESCRIPTION
Adds a free, no-signup **Nordic Take-Home Pay Calculator** to the Finances section, alongside the existing German Salary and FEIE calculators.

It computes gross-to-net salary for **Denmark, Sweden, Norway, and Finland** on official 2026 tax rates, and includes feriepenge (holiday pay), dagpenge, and gross-up tools — genuinely useful for expats working out what they'll actually take home before relocating.

No signup, no paywall. Fits the existing calculator entries in the section.