### PR TITLE
Add Banking Access Index to Finances

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@
 * [Nordic Take-Home Pay Calculator](https://nordicexpat.com/tools) - Free, no-signup gross-to-net salary calculators for Denmark, Sweden, Norway, and Finland on official 2026 tax rates, plus feriepenge (holiday pay), dagpenge, and gross-up tools.
 * [US Expat Tax Guide: Maintaining Florida Domicile](https://yourtaxbase.com/expat-tax-guide) - Free 2026 guide for US citizens abroad on legally eliminating state income tax by keeping domicile in a no-tax state, alongside federal exclusions and filing requirements.
 * [Awesome Digital Nomads](https://github.com/cloudfloo/awesome-digital-nomads) - Curated, link-checked list of tools and resources for digital nomads: finance and FIRE, visas, insurance, eSIMs, accommodation, and communities.
+* [Banking Access Index](https://www.globalsolo.global/data/banking-access-index) - Free CC-BY dataset of which 18 US banking providers accept non-US-resident business owners, across 8 countries — 239 claims verified against published policies, with CSV/JSON downloads.
 ## Misc
 
 * [SeeYourFolks](http://seeyourfolks.com) - We’re so busy growing up that we sometimes forget that they are also growing old.


### PR DESCRIPTION
Adds the Banking Access Index — a free CC-BY dataset tracking which US banking providers (banks + fintechs) accept non-US-resident business owners, per country, with each claim verified against the provider's published policy (evidence quotes included; explicit-accept / explicit-restrict / no-published-restriction tri-state). Useful to expats and non-residents who keep hitting "can I even open a US business account from my country". CSV/JSON downloads, updated quarterly.

Disclosure: I built and maintain this dataset.