### PR TITLE
Add IndepAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@
 * [US Expat Tax Guide: Maintaining Florida Domicile](https://yourtaxbase.com/expat-tax-guide) - Free 2026 guide for US citizens abroad on legally eliminating state income tax by keeping domicile in a no-tax state, alongside federal exclusions and filing requirements.
 * [Awesome Digital Nomads](https://github.com/cloudfloo/awesome-digital-nomads) - Curated, link-checked list of tools and resources for digital nomads: finance and FIRE, visas, insurance, eSIMs, accommodation, and communities.
 * [Banking Access Index](https://www.globalsolo.global/data/banking-access-index) - Free CC-BY dataset of which 18 US banking providers accept non-US-resident business owners, across 8 countries — 239 claims verified against published policies, with CSV/JSON downloads.
+* [IndepAI Coast FIRE Calculator](https://indepai.app/tools/coast-fire-calculator) - Free calculator that shows the age you can stop saving and coast to retirement, built for expats juggling multiple currencies and relocation plans. No signup needed.
 ## Misc
 
 * [SeeYourFolks](http://seeyourfolks.com) - We’re so busy growing up that we sometimes forget that they are also growing old.


### PR DESCRIPTION
IndepAI is a free FIRE (Financial Independence, Retire Early) calculator suite for digital nomads and expats. This links the Coast FIRE calculator: find the age you can stop saving and still retire, plus cost-of-living data for 11,400+ cities to see where your money goes further.

The calculators are free to use with no login required. Adding it under Finances alongside the other cost-of-living and tax tools since it targets the same relocation and geo-arbitrage planning use case.