### PR TITLE
Add Spain, United Kingdom and France sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@
 
 * [NordicExpat](https://nordicexpat.com) - Comprehensive relocation guides for non-EU expats moving to Denmark, Sweden, Norway, and Finland. Covers banking (Wise, Revolut), housing, taxes, healthcare, visas, and everyday life. Includes free tools: Copenhagen zone calculator, Nordic tax calculators, and country-specific benefit guides. 160+ in-depth articles authored by an expat in the region.
 
+### France
+
+* [Actero](https://actero.ro) - Free Romanian-language guide for Romanians in France handling paperwork at the Romanian Consulate: passport renewal, national ID (buletin), powers of attorney (procură notarială), and birth/marriage certificate transcriptions.
+
+### Spain
+
+* [Actero](https://actero.ro) - Free Romanian-language guide for Romanians in Spain handling paperwork at the Romanian Consulate: passport renewal, national ID (buletin), powers of attorney (procură notarială), and birth/marriage certificate transcriptions.
+
+### United Kingdom
+
+* [Actero](https://actero.ro) - Free Romanian-language guide for Romanians in the UK handling paperwork at the Romanian Consulate: passport renewal, national ID (buletin), powers of attorney (procură notarială), and birth/marriage certificate transcriptions.
+
 ## Interviewing
 
 * [Awesome Interview Questions](https://github.com/MaximAbramchuck/awesome-interview-questions) - A curated awesome list of lists of interview questions.


### PR DESCRIPTION
This PR adds three new country sections — France, Spain, and United Kingdom — following the pattern of Korea and Nordics (single-country curated entry per section).

Each section has one entry, Actero (actero.ro), which is the same Romanian-language consular-paperwork guide already merged under Germany and Italy in #28. The service covers the Romanian consulates in these three countries with the same scope: passport renewal, national ID (buletin), powers of attorney (procură notarială), and birth/marriage certificate transcriptions for children born abroad.

The three countries have significant Romanian diaspora populations that rely on the corresponding consulates:
- Spain: ~1M Romanians (largest Romanian diaspora in Europe)
- - United Kingdom: ~700k Romanians
- - France: ~200k Romanians
Sections are appended at the end of the country list — happy to reorder to alphabetical or any other grouping you prefer.

**Disclosure:** I'm the Content Lead at Actero.